### PR TITLE
Fix get_last_lr value

### DIFF
--- a/warmup_scheduler/scheduler.py
+++ b/warmup_scheduler/scheduler.py
@@ -57,6 +57,7 @@ class GradualWarmupScheduler(_LRScheduler):
                     self.after_scheduler.step(None)
                 else:
                     self.after_scheduler.step(epoch - self.total_epoch)
+                self._last_lr = self.after_scheduler.get_last_lr()
             else:
                 return super(GradualWarmupScheduler, self).step(epoch)
         else:


### PR DESCRIPTION
```get_lr()``` was deprecated and instead the method intended to be used for getting the current lr is ```get_last_lr()```. This is in the context of checking from exterior the current learning rate.

Currently, once the after warmup scheduler kicks in the returned value was wrong.