### PR TITLE
fix when after_scheduler=StepLR, and step_size=1

### DIFF
--- a/warmup_scheduler/scheduler.py
+++ b/warmup_scheduler/scheduler.py
@@ -23,7 +23,7 @@ class GradualWarmupScheduler(_LRScheduler):
         super(GradualWarmupScheduler, self).__init__(optimizer)
 
     def get_lr(self):
-        if self.last_epoch > self.total_epoch:
+        if self.last_epoch >= self.total_epoch:
             if self.after_scheduler:
                 if not self.finished:
                     self.after_scheduler.base_lrs = [base_lr * self.multiplier for base_lr in self.base_lrs]


### PR DESCRIPTION
when after_scheduler=StepLR(step_size=1), there is a problem with the lr, at the first epoch of after_scheduler work.
for example:
```
model = [torch.nn.Parameter(torch.randn(2, 2, requires_grad=True))]
optim = SGD(model, 0.1)
scheduler_steplr = StepLR(optim, step_size=1, gamma=0.1)
scheduler_warmup = GradualWarmupScheduler(optim, multiplier=1, total_epoch=5, after_scheduler=scheduler_steplr)
optim.zero_grad()
optim.step()
for epoch in range(1, 10):
    scheduler_warmup.step(epoch)
    print(epoch, optim.param_groups[0]['lr'])

    optim.step()    # backward pass (update network
```

output:
1 0.020000000000000004
2 0.04000000000000001
3 0.06
4 0.08000000000000002
5 0.1
**6 0.1**
7 0.0010000000000000002
8 0.00010000000000000003
9 1.0000000000000003e-05

the lr of epoch 6 should be 0.01.

with fix at this pull. the problem has been fixed.