### PR TITLE
Update scheduler.py

### DIFF
--- a/warmup_scheduler/scheduler.py
+++ b/warmup_scheduler/scheduler.py
@@ -1,5 +1,6 @@
 from torch.optim.lr_scheduler import _LRScheduler
 from torch.optim.lr_scheduler import ReduceLROnPlateau
+import warnings
 
 
 class GradualWarmupScheduler(_LRScheduler):
@@ -23,6 +24,9 @@ class GradualWarmupScheduler(_LRScheduler):
         super(GradualWarmupScheduler, self).__init__(optimizer)
 
     def get_lr(self):
+        if not self._get_lr_called_within_step:
+            warnings.warn("To get the last learning rate computed by the scheduler, "
+                          "please use `get_last_lr()`.")        
         if self.last_epoch > self.total_epoch:
             if self.after_scheduler:
                 if not self.finished:


### PR DESCRIPTION
I've added the warning to get_lr to only be called within "step". I think this is standard for Pytorch schedulers, so it might be savvy to include this.