### PR TITLE
Exclude optimizer instances from the state_dict

### DIFF
--- a/warmup_scheduler/scheduler.py
+++ b/warmup_scheduler/scheduler.py
@@ -62,3 +62,12 @@ class GradualWarmupScheduler(_LRScheduler):
                 return super(GradualWarmupScheduler, self).step(epoch)
         else:
             self.step_ReduceLROnPlateau(metrics, epoch)
+    
+    def state_dict(self):
+        state_dict = {key: value for key, value in self.__dict__.items() if key not in ['optimizer', 'after_scheduler']}
+        state_dict.update({"after_scheduler": self.after_scheduler.state_dict()})
+        return state_dict
+
+    def load_state_dict(self, state_dict):
+        self.after_scheduler.load_state_dict(state_dict.pop("after_scheduler"))
+        self.__dict__.update(state_dict)


### PR DESCRIPTION
If attribute 'optimizer' as a python object are pickled together, one may encounter a compatibility issue when loading it back.
(unless the same optimizer module is imported from the same path to recognize the saved attributes.)

The `self.optimizer`, by default, expected to be filtered out, but `self.after_scheduler.optimizer` has to be taken into account as well. So, I've overriden relevant methods to exclude optimizer instances from the state_dict.