### PR TITLE
Fix: epoch does not increase after finishing warming up

### DIFF
--- a/warmup_scheduler/scheduler.py
+++ b/warmup_scheduler/scheduler.py
@@ -57,6 +57,7 @@ class GradualWarmupScheduler(_LRScheduler):
                     self.after_scheduler.step(None)
                 else:
                     self.after_scheduler.step(epoch - self.total_epoch)
+                self.last_epoch = self.after_scheduler.last_epoch + self.total_epoch + 1
                 self._last_lr = self.after_scheduler.get_last_lr()
             else:
                 return super(GradualWarmupScheduler, self).step(epoch)


### PR DESCRIPTION
After the warming up phase, executing `scheduler_warmup.step()` does not affect `scheduler_warmup.last_epoch`
Since in `scheduler_warmup.step`, either epoch is None or not, `self.after_scheduler.step` updates `self.after_scheduler.last_epoch` instead of `self.last_epoch`. And it is reasonable to add `self.total_epoch + 1` to make epochs seem to be continuing.